### PR TITLE
*FIX [App:Extend()] 1.0.7 setColLengthなどコールバックを使用して盤面データの更新処理を同期化、Auto stepでの未更新バグ解消 > [Bug] 自動ステップ作動時、自動拡張が行われない。 #4  1.0.7 k

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "lifegame_0",
     "private": true,
-    "version": "1.0.6-j",
+    "version": "1.0.7-k",
     "type": "module",
     "author": "NobuoJT",
     "copyright": "2025 NobuoJT",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -448,21 +448,24 @@ function extend(){
 
   const row_data:boolean[][]=[]  //行データ
   let   col_data:boolean[]=[]    //列データ
-  setColLength(col_length+2)
-  setRowLength(row_length+2)
-  for(let c=0;c<row_length+2;c++){
-    col_data=[]
-    for(let r=0;r<col_length+2;r++){    
-      if(c>0&&r> 0&& c<tableData.length+1&&r<tableData[c-1].length+1){
-        col_data.push(tableData[c-1][r-1])
-      }else{
-        col_data.push(false)
+  setColLength((col_l)=>{
+    setRowLength((row_l)=>{
+      setTableData((td)=>{
+      for(let c=0;c<row_l+2;c++){
+        col_data=[]
+        for(let r=0;r<col_l+2;r++){    
+          if(c>0&&r> 0&& c<td.length+1&&r<td[c-1].length+1){
+            col_data.push(td[c-1][r-1])
+          }else{
+            col_data.push(false)
+          }
+        }
+        row_data.push(col_data)
       }
-    }
-    row_data.push(col_data)
-  }
-  table_mapped=true
-  setTableData(row_data)   //盤面更新
+      table_mapped=true
+      return row_data})   //盤面更新
+    return row_l+2})
+  return col_l+2})
 
 }
 

--- a/startup_memo.md
+++ b/startup_memo.md
@@ -109,10 +109,17 @@ GitHubのライセンス本文とlicenses/へのリンクを貼る。
 
 # 詰まったところ
 
-Red Hat Dependency Analyticsが勝手に
-package.jsonの"name":hogehogeから"devDependencies"の下、hogehoge:"file:"に意地でも書こうとしてくるから、
-依存関係の循環参照になって詰まった。
-拡張機能をアンインストールして解決。
+## 循環参照
+Red Hat Dependency Analyticsが勝手に  
+package.jsonの"name":hogehogeから"devDependencies"の下、hogehoge:"file:"に意地でも書こうとしてくるから、  
+依存関係の循環参照になって詰まった。  
+拡張機能をアンインストールして解決。  
+
+## useState()
+```const [v,setFunc]=useState()```での```getFunc(v++)```は非同期的に実行されるため  
+関数内の```v```は現在の状態ではないかもしれない。  
+```setFunc((now_v)=>{return now_v++})```を使うことで現在の```v```を取得して実行が可能。  
+しかし、関わる変数が増えるとネストが増えるので、そういう処理は```useReducer()```を定義するべき。
 
 # docker commands
 


### PR DESCRIPTION
*FIX App:Extend() 1.0.7

- `setColLength` および `setRowLength` のコールバックを使用してボードデータの更新プロセスを同期。  
- これにより自動ステップ実行中に自動拡張が行われないバグを修正。
- #4 で特定された問題が解消され、ボードの端に生存セルが存在する場合でも適切な機能が確保されます。

close #4 